### PR TITLE
Adding the 'icons' directory to the binary build

### DIFF
--- a/gov.lbnl.visit.swt/build.properties
+++ b/gov.lbnl.visit.swt/build.properties
@@ -1,6 +1,7 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               icons/
 src.includes = META-INF/,\
                src/


### PR DESCRIPTION
This adds the icons to the buttons rather than having blank or error buttons.
