### PR TITLE
UI thread use removed from VisItSwtConnectionManager

### DIFF
--- a/gov.lbnl.visit.swt/src/gov/lbnl/visit/swt/VisItSwtConnectionManager.java
+++ b/gov.lbnl.visit.swt/src/gov/lbnl/visit/swt/VisItSwtConnectionManager.java
@@ -46,12 +46,11 @@ public class VisItSwtConnectionManager {
         return null;
     }
 
-    public static VisItSwtConnection createConnection(String key,
-            Display display, Map<String, String> inputMap) {
+	public static VisItSwtConnection createConnection(String key, Shell shell,
+			Map<String, String> inputMap) {
 
-        try {
-            VisItSwtConnection vizConnection = new VisItSwtConnection(
-                    new Shell(display));
+		try {
+			VisItSwtConnection vizConnection = new VisItSwtConnection(shell);
 
             String username = inputMap.get("username");
             String password = inputMap.get("password");

--- a/gov.lbnl.visit.swt/src/gov/lbnl/visit/swt/VisItSwtWidget.java
+++ b/gov.lbnl.visit.swt/src/gov/lbnl/visit/swt/VisItSwtWidget.java
@@ -406,9 +406,13 @@ public class VisItSwtWidget extends Canvas implements Listener,
         final byte[] output = rawData;
         Display.getDefault().asyncExec(new Runnable() {
             public void run() {
-                ByteArrayInputStream bis = new ByteArrayInputStream(output);
-                image = new Image(shell.getDisplay(), bis);
-                redraw();
+				// Check that the canvas is properly constructed and not
+				// disposed before attempting to draw.
+            	if (!isDisposed()) {
+	                ByteArrayInputStream bis = new ByteArrayInputStream(output);
+	                image = new Image(shell.getDisplay(), bis);
+	                redraw();
+            	}
             }
         });
     }


### PR DESCRIPTION
Converting a parameter for
VisItSwtConnectionManager.createConnection(...) from Display to Shell.
This is so client code can pass in a pre-constructed (on the UI thread)
shell to the VisItSwtConnectionManager. Otherwise, calling
VisItSwtConnectionManager.createConnection(...) must block the UI thread
because a Shell is created.